### PR TITLE
Dual axis scatterplot modifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/react-dom": "^0.14.20",
     "@types/lodash": "^4.14.50",
     "d3-brush": "^1.0.3",
-    "datavisyn-scatterplot": "github:datavisyn/datavisyn-scatterplot",
+    "datavisyn-scatterplot": "github:datavisyn/datavisyn-scatterplot#dual-axis-scatterplot",
     "lodash": "^4.17.4",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"

--- a/src/LocusZoom.ts
+++ b/src/LocusZoom.ts
@@ -8,8 +8,8 @@
 import * as React from 'react';
 import merge from 'datavisyn-scatterplot/src/merge';
 import {formatPrefix} from 'd3-format';
-import {EScaleAxes, IScatterplotOptions} from 'datavisyn-scatterplot/src';
-export {IScatterplotOptions} from 'datavisyn-scatterplot/src';
+import {EScaleAxes, IScatterplotOptions, IScatterplotBaseOptions} from 'datavisyn-scatterplot/src';
+export {IScatterplotOptions, IScatterplotBaseOptions} from 'datavisyn-scatterplot/src';
 import Scatterplot, {IScatterplotProps} from './index';
 
 export interface ILocusZoomProps<T> extends IScatterplotProps<T> {
@@ -37,21 +37,24 @@ export default class LocusZoom<T> extends React.Component<ILocusZoomProps<T>,{}>
   }
 
   render() {
+    const baseOptions: IScatterplotBaseOptions<T> = {
+        margin: {
+          left: 50,
+          bottom: 30
+        },
+        format: {
+          x: formatPrefix('.2', 1e6) // SI-prefix with two significant digits, "42M"
+        },
+        zoom: {
+          scale: EScaleAxes.x
+        },
+        aspectRatio: 5 // a wild guess that x is 5 times as width as height
+    };
+
     const options: IScatterplotOptions<T> = {
-      margin: {
-        left: 50,
-        bottom: 30
-      },
-      format: {
-        x: formatPrefix('.2', 1e6) // SI-prefix with two significant digits, "42M"
-      },
-      zoom: {
-        scale: EScaleAxes.x
-      },
       xlabel: this.props.chromosome,
       ylabel: '-log10 p-value',
-      aspectRatio: 5 // a wild guess that x is 5 times as width as height
     };
-    return React.createElement(Scatterplot, merge({options}, this.props));
+    return React.createElement(Scatterplot, merge({options}, {baseOptions}, this.props.baseOptions, this.props.options, this.props));
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,8 @@
 
 import * as React from 'react';
 import merge from 'datavisyn-scatterplot/src/merge';
-import Impl, {IScatterplotOptions, IWindow} from 'datavisyn-scatterplot/src';
-export {scale, symbol, IScatterplotOptions} from 'datavisyn-scatterplot/src';
+import Impl, {IScatterplotOptions, IScatterplotBaseOptions, IWindow} from 'datavisyn-scatterplot/src';
+export {scale, symbol, IScatterplotOptions, IScatterplotBaseOptions} from 'datavisyn-scatterplot/src';
 export {default as QQPlot, IQQPlotProps} from './qqplot';
 export {default as ManhattanPlot} from './ManhattanPlot';
 import {isEqual} from 'lodash';
@@ -21,6 +21,7 @@ export interface IScatterplotProps<T> {
   selection?: T[];
 
   options?: IScatterplotOptions<T>;
+  baseOptions?: IScatterplotBaseOptions<T>;
 
   onSelectionChanged?(selection: T[]);
   onWindowChanged?(window: IWindow);
@@ -53,12 +54,13 @@ export default class Scatterplot<T> extends React.Component<IScatterplotProps<T>
   private build() {
     this.renderedProps = {
       options: merge({}, this.props.options),
+      baseOptions: merge({}, this.props.baseOptions),
       data: this.props.data
     };
     if (this.plot) {
       this.parent.innerHTML = ''; //clear
     }
-    this.plot = new Impl(this.renderedProps.data, this.parent, this.renderedProps.options);
+    this.plot = new Impl(this.renderedProps.data, this.parent, this.renderedProps.options, this.renderedProps.baseOptions);
     this.plot.on(Impl.EVENT_SELECTION_CHANGED, this.onSelectionChanged.bind(this));
     if (this.props.onWindowChanged) {
       this.plot.on(Impl.EVENT_WINDOW_CHANGED, this.props.onWindowChanged);


### PR DESCRIPTION
These are some little modifications the reflect the current changes in the datavisyn-scatterplot#dual-axis-scatterplot branch, where I separated the baseOptions (for AScatterplot) and the options for the subclasses (Scatterplot & DualAxisScatterplot)